### PR TITLE
Be able to add package external EventHandlers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,6 @@ jobs:
 
       - name: Run behave
         run: pipenv run behave
+
+      - name: Run test suite
+        run: pipenv run test -v

--- a/Pipfile
+++ b/Pipfile
@@ -23,4 +23,4 @@ pytest = "*"
 allow_prereleases = true
 
 [scripts]
-test = "pytest"
+test = "bash -c \"PYTHONPATH=$PWD/.:$PWD/test/unit:$PYTHONPATH pytest\""

--- a/Pipfile
+++ b/Pipfile
@@ -17,6 +17,10 @@ pylint = "*"
 rope = "*"
 behave = "*"
 deepdiff = "*"
+pytest = "*"
 
 [pipenv]
 allow_prereleases = true
+
+[scripts]
+test = "pytest"

--- a/README.md
+++ b/README.md
@@ -347,13 +347,15 @@ sync:
   groups:
     <group synchronization information>
   event_handler:
-    name: <event handler class name to instantiate>
+    name: <SRAMsync event handler class name to instantiate>
     config:
       <configuration belonging to the instantiated EventHandler class>
   grace:
     <group names for which to apply a grace period>:
       grace_period: <grace period in days>
 ```
+
+Note: Alternatively one can also specify an external Eventhandler via `class: <package.module.Class>` and omitting the `name` property.
 
 #### groups
 

--- a/README.md
+++ b/README.md
@@ -355,8 +355,6 @@ sync:
       grace_period: <grace period in days>
 ```
 
-Note: Alternatively one can also specify an external Eventhandler via `class: <package.module.Class>` and omitting the `name` property.
-
 #### groups
 
 The group block specifies what groups need to be synced from SRAM. You must
@@ -560,7 +558,10 @@ times.
 ## EventHandler Classes
 
 A few EventHandler classes are available. Each has its own configuration and
-can be selected in the configuration file.
+can be selected in the configuration file by simply specifying the name of 
+the EventHandler in the `name` property.
+
+For creating your own custom EventHandler implementation see [below](#creating-a-custom-eventhandler). 
 
 ### DummyEventandler
 
@@ -799,3 +800,34 @@ The above example shows plain text passwords in the configuration file. Instead
 of using the `passwd` in the `smtp` block, one could also use `passwd_from_secrets`.
 This only works if you have opted to use the `secrets` block in the configuration.
 See [Password file format](#password-file-format) for more information.
+
+### Creating a custom EventHandler
+
+Alternatively one can also specify their own EventHandler class by setting the
+`name` property to the exact package & module name of the class.
+
+Assume we have the following EventHandler in the file `my_event_handler.py`
+in the folder `my_package`:
+
+```python
+from SRAMsync.event_handler import EventHandler
+
+class MyEventHandler(EventHandler):
+  <implementation of all abstract methods>
+```
+
+Then the `event_handler` property needs to be set to
+```yaml
+sync:
+  <other sync parameters ...>
+  event_handler:
+    name: my_package.my_event_handler.MyEventHandler
+    config:
+      <MyEventHandlerConfig (optional)>
+```
+
+The sources only need to be visible via `PYTHONPATH`:
+```bash
+export PYTHONPATH=/path/to/source/:$PYTHONPATH
+sync-with-sram -d path/to/config.yaml
+```

--- a/SRAMsync/common.py
+++ b/SRAMsync/common.py
@@ -1,5 +1,7 @@
 """Common functionalities."""
+import importlib
 import re
+from typing import Type
 
 
 def render_templated_string(template_string: str, **kw: str) -> str:
@@ -15,3 +17,24 @@ def pascal_case_to_snake_case(string: str) -> str:
     string = re.sub(r"([a-z])([A-Z])", r"\1_\2", string)
 
     return string.lower()
+
+
+def deduct_event_handler_class(event_handler_full_name: str) -> Type:
+    """
+    Deduct the event handler class to import from the given name. 
+    Names can be e.g. 
+    - (old style) DummyEventHandler which will be translated to SRA
+    """
+    if "." in event_handler_full_name:
+        # if there is a "." in the name we assume its a full package name
+        components = event_handler_full_name.split('.')
+        event_handler_class_name = components[-1]
+        event_handler_module_name = '.'.join(components[0:-1])       
+    else:
+        # default to "SRAMsync" package if nothing special (old behaviour)
+        # is specified in the "name" attribute
+        event_handler_class_name = event_handler_full_name
+        event_handler_module_name = "SRAMsync." + pascal_case_to_snake_case(event_handler_class_name)
+    
+    event_handler_module = importlib.import_module(event_handler_module_name)
+    return getattr(event_handler_module, event_handler_class_name)

--- a/SRAMsync/config.py
+++ b/SRAMsync/config.py
@@ -3,7 +3,6 @@
   the main configuration. EventHandler classes may extent the
   configuration.
 """
-import importlib
 import json
 from typing import Any
 
@@ -11,7 +10,7 @@ import yaml
 from jsonschema import validate
 from ldap import ldapobject
 
-from .common import pascal_case_to_snake_case
+from .common import deduct_event_handler_class
 from .event_handler import EventHandler
 
 
@@ -139,21 +138,7 @@ class Config:
 
         event_handler_section = self.config["sync"]["event_handler"]
 
-        event_handler_full_name = event_handler_section["name"]
-        if "." in event_handler_full_name:
-            # if there is a "." in the name we assume its a full package name
-            components = event_handler_full_name.split('.')
-            event_handler_class_name = components[-1]
-            event_handler_module_name = '.'.join(components[0:-1])
-            event_handler_module = importlib.import_module(event_handler_module_name)
-        else:
-            # default to "SRAMsync" package if nothing special (old behaviour)
-            # is specified in the "name" attribute
-            event_handler_class_name = event_handler_full_name
-            event_handler_module_name = pascal_case_to_snake_case(event_handler_class_name)
-            event_handler_module = importlib.import_module(f"SRAMsync.{event_handler_module_name}")
-
-        event_handler_class = getattr(event_handler_module, event_handler_class_name)
+        event_handler_class = deduct_event_handler_class(event_handler_section["name"])
 
         handler_cfg = {}
         if "config" in event_handler_section:

--- a/test/unit/external_event_handler/my_external_event_handler.py
+++ b/test/unit/external_event_handler/my_external_event_handler.py
@@ -1,0 +1,5 @@
+from SRAMsync.event_handler import EventHandler
+
+
+class MyExternalEventHandler(EventHandler):
+    pass

--- a/test/unit/test_common.py
+++ b/test/unit/test_common.py
@@ -1,0 +1,26 @@
+
+import pytest
+
+from SRAMsync.common import deduct_event_handler_class
+from SRAMsync.event_handler import EventHandler
+from SRAMsync.dummy_event_handler import DummyEventHandler
+
+from external_event_handler.my_external_event_handler import MyExternalEventHandler
+
+
+class MyEventHandler(EventHandler):
+    pass
+
+
+def test_deduct_event_handler_class():
+    # make sure that the standard SRAMsync lookup still works
+    assert deduct_event_handler_class('DummyEventHandler') == DummyEventHandler
+
+    # test the new loaded with a local event handler
+    assert deduct_event_handler_class('test_common.MyEventHandler') == MyEventHandler
+
+    # test the new loaded with an event handler in a different package
+    assert deduct_event_handler_class('external_event_handler.my_external_event_handler.MyExternalEventHandler') == MyExternalEventHandler
+
+    with pytest.raises(ModuleNotFoundError):
+        deduct_event_handler_class("my_package.my_module.NotExistingEventHandler")


### PR DESCRIPTION
I added a new (backwards-compatible) way to specify the EventHandler in the config file e.g.

```
  event_handler:
    class: vsc_event_handler.VSCEventHandler
    config:
       <config object>
```